### PR TITLE
remove raise from object managers where the result is no objects

### DIFF
--- a/moxtoolsite/catalog/models.py
+++ b/moxtoolsite/catalog/models.py
@@ -315,10 +315,7 @@ class SharedModelPermissionManager(models.Manager):
                                 queryset = queryset | Genre.objects.filter(id=trackinstance.track.genre.id)
                             else:
                                 raise ValidationError("Data for "+shared_model+" is not currently available.")
-                if queryset.count() >= 1:
-                    return queryset.distinct()
-                else:
-                    raise PermissionDenied("You do not have permission to view any "+shared_model+"s.")
+                return queryset.distinct()
             else:
                 raise ValidationError("The request for "+shared_model+" is not a valid shared model.")
 
@@ -331,7 +328,8 @@ class SharedModelPermissionManager(models.Manager):
                 if user.has_perm('catalog.moxtool_can_modify_any_'+shared_model):
                     return self.get_queryset()
                 else:
-                    raise PermissionDenied("You do not have permission to directly modify "+shared_model+"s.")
+                    model = self.model
+                    return model.objects.none()
             else:
                 raise ValidationError("The request for "+shared_model+" is not a valid shared model.")
 
@@ -359,10 +357,7 @@ class SharedModelPermissionManager(models.Manager):
                                 queryset = queryset | Genre.objects.filter(id=trackinstance.track.genre.id)
                             else:
                                 raise ValidationError("Data for "+shared_model+" is not currently available.")
-                    if queryset.count() >= 1:
-                        return queryset.distinct()
-                    else:
-                        raise PermissionDenied("You do not have permission to request modifications to "+shared_model+"s.")
+                    return queryset.distinct()
             else:
                 raise ValidationError("The request for "+shared_model+" is not a valid shared model.")
 
@@ -584,7 +579,8 @@ class UserRequestPermissionManager(models.Manager):
                 elif user.has_perm('catalog.moxtool_can_view_own_'+request_model):
                     return self.get_queryset().filter(user=user)
                 else:
-                    raise PermissionDenied("You do not have permission to view any tags.")
+                    model = self.model
+                    return model.objects.none()
             except:
                 raise ValidationError("The request for "+request_model+" is not a valid user request model.")
 
@@ -599,7 +595,8 @@ class UserRequestPermissionManager(models.Manager):
                 elif user.has_perm('catalog.moxtool_can_modify_own_'+request_model):
                     return self.get_queryset().filter(user=user)
                 else:
-                    raise PermissionDenied("You do not have permission to directly modify any tags.")
+                    model = self.model
+                    return model.objects.none()
             except:
                 raise ValidationError("The request for "+request_model+" is not a valid user model.")
         
@@ -796,7 +793,8 @@ class UserModelPermissionManager(models.Manager):
                 elif user.has_perm('catalog.moxtool_can_view_own_'+user_model):
                     return self.get_queryset().filter(user=user)
                 else:
-                    raise PermissionDenied("You do not have permission to view any tags.")
+                    model = self.model
+                    return model.objects.none()
             else:
                 raise ValidationError("The request for "+user_model+" is not a valid user model.")
 
@@ -811,7 +809,8 @@ class UserModelPermissionManager(models.Manager):
                 elif user.has_perm('catalog.moxtool_can_modify_own_'+user_model):
                     return self.get_queryset().filter(user=user)
                 else:
-                    raise PermissionDenied("You do not have permission to directly modify any tags.")
+                    model = self.model
+                    return model.objects.none()
             else:
                 raise ValidationError("The request for "+user_model+" is not a valid user model.")
 
@@ -833,7 +832,8 @@ class UserModelPermissionManager(models.Manager):
                     if queryset.count() >= 1:
                         return queryset.distinct()
                     else:
-                        raise PermissionDenied("You do not have permission to request modifications to "+shared_model+"s.")
+                        model = self.model
+                        return model.objects.none()
             else:
                 raise ValidationError("The request for "+shared_model+" is not a valid shared model.")
 

--- a/moxtoolsite/catalog/tests/test_models.py
+++ b/moxtoolsite/catalog/tests/test_models.py
@@ -119,7 +119,7 @@ class ArtistModelTest(TestCase, CatalogTestMixin):
         all_artists = Artist.objects.all()
         self.assertRaises(PermissionDenied, Artist.objects.get_queryset_can_direct_modify, (self.users['anonymous']))
         self.client.force_login(self.users['dj'])
-        self.assertRaises(PermissionDenied, Artist.objects.get_queryset_can_direct_modify, (self.users['dj']))
+        self.assertEqual(set(Artist.objects.get_queryset_can_direct_modify(self.users['dj'])), set(Artist.objects.none()))
         self.client.force_login(self.users['admin'])
         self.assertEqual(set(Artist.objects.get_queryset_can_direct_modify(self.users['admin'])), set(all_artists))
 
@@ -280,7 +280,7 @@ class GenreModelTest(TestCase, CatalogTestMixin):
         all_genres = Genre.objects.all()
         self.assertRaises(PermissionDenied, Genre.objects.get_queryset_can_direct_modify, (self.users['anonymous']))
         self.client.force_login(self.users['dj'])
-        self.assertRaises(PermissionDenied, Genre.objects.get_queryset_can_direct_modify, (self.users['dj']))
+        self.assertEqual(set(Genre.objects.get_queryset_can_direct_modify(self.users['dj'])), set(Genre.objects.none()))
         self.client.force_login(self.users['admin'])
         self.assertEqual(set(Genre.objects.get_queryset_can_direct_modify(self.users['admin'])), set(all_genres))
 
@@ -532,7 +532,7 @@ class TrackModelTest(TestCase, CatalogTestMixin):
         all_tracks = Track.objects.all()
         self.assertRaises(PermissionDenied, Track.objects.get_queryset_can_direct_modify, (self.users['anonymous']))
         self.client.force_login(self.users['dj'])
-        self.assertRaises(PermissionDenied, Track.objects.get_queryset_can_direct_modify, (self.users['dj']))
+        self.assertEqual(set(Track.objects.get_queryset_can_direct_modify(self.users['dj'])), set(Track.objects.none()))
         self.client.force_login(self.users['admin'])
         self.assertEqual(set(Track.objects.get_queryset_can_direct_modify(self.users['admin'])), set(all_tracks))
 


### PR DESCRIPTION
allows a zero result to occur without error if a user is logged in